### PR TITLE
fix: undefined class facade ImageOptimizer

### DIFF
--- a/src/Facades/ImageOptimizer.php
+++ b/src/Facades/ImageOptimizer.php
@@ -9,8 +9,8 @@ use Illuminate\Support\Facades\Facade;
  */
 class ImageOptimizer extends Facade
 {
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
-        return \Joshembling\ImageOptimizer\ImageOptimizer::class;
+        return self::class;
     }
 }


### PR DESCRIPTION
## Issue:
- undefined class `ImageOptimizer` and method `->optimize()` not showing in my editor phpStrorm

## Todo:
- fixing path class ImageOptimizer

## Screenshot:
| Case         | Images |
|--------------|--------|
| Issue        |    ![image](https://github.com/joshembling/image-optimizer/assets/41967704/f041e3a6-3197-4293-9fd0-dfdb4b98461f) |
| After fixing | ![image](https://github.com/joshembling/image-optimizer/assets/41967704/5f0c4c2c-34de-4cd7-a43f-22b3d248b59a) |