### PR TITLE
handle afterStateUpdated as array

### DIFF
--- a/src/Components/BaseFileUpload.php
+++ b/src/Components/BaseFileUpload.php
@@ -278,9 +278,9 @@ class BaseFileUpload extends Field
 
     public function callAfterStateUpdated(): static
     {
-        if ($callback = $this->afterStateUpdated) {
-            $state = $this->getState();
+        $state = $this->getState();
 
+        foreach ($this->afterStateUpdated as $callback) {
             $this->evaluate($callback, [
                 'state' => $this->isMultiple() ? $state : Arr::first($state ?? []),
             ]);


### PR DESCRIPTION
change evaluation of afterStateUpdated-callbacks to foreach in BaseFileUpload:279 function callAfterStateUpdated
Should fix bug [#17](https://github.com/joshembling/image-optimizer/issues/17) and [#29](https://github.com/joshembling/image-optimizer/issues/29)