### PR TITLE
Fixed maxParallelUploads attribute bug

### DIFF
--- a/src/Components/BaseFileUpload.php
+++ b/src/Components/BaseFileUpload.php
@@ -48,6 +48,8 @@ class BaseFileUpload extends Field
 
     protected int | Closure | null $minSize = null;
 
+    protected int | Closure | null $maxParallelUploads = null;
+
     protected int | Closure | null $maxFiles = null;
 
     protected int | Closure | null $minFiles = null;
@@ -451,6 +453,13 @@ class BaseFileUpload extends Field
         return $this;
     }
 
+    public function maxParallelUploads(int | Closure | null $count): static
+    {
+        $this->maxParallelUploads = $count;
+
+        return $this;
+    }
+
     public function maxFiles(int | Closure | null $count): static
     {
         $this->maxFiles = $count;
@@ -620,6 +629,11 @@ class BaseFileUpload extends Field
     public function getResize(): ?int
     {
         return $this->evaluate($this->resize);
+    }
+
+    public function getMaxParallelUploads(): ?int
+    {
+        return $this->evaluate($this->maxParallelUploads);
     }
 
     public function getVisibility(): string


### PR DESCRIPTION
This pull request adds a maxParallelUploads() method to control how many parallel uploads happen at once.
Although this is a useful method by itself, it also allows a simple workaround for https://github.com/filamentphp/filament/issues/15308

This replicates to the BaseFileUpload of this plugin thus fixing the issue https://github.com/joshembling/image-optimizer/issues/38