### PR TITLE
Add Conditional Image Resizing Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,19 @@ SpatieMediaLibraryFileUpload::make('attachment')
     ->resize(50),
 `````
 
+### Add maximum width and/or height
+
+You can also add a maximum width and/or height to the image. This will resize the image to the maximum width and/or height, maintaining the aspect ratio.
+
+`````php
+use Filament\Forms\Components\FileUpload;
+
+FileUpload::make('attachment')
+    ->image()
+    ->maxWidth(1024)
+    ->maxHeight(768),
+`````
+
 ### Combining methods
 
 You can combine these two methods for maximum optimization.

--- a/src/Components/BaseFileUpload.php
+++ b/src/Components/BaseFileUpload.php
@@ -207,7 +207,7 @@ class BaseFileUpload extends Field
             $resize = $component->getResize();
             $maxImageWidth = $component->getMaxImageWidth();
             $maxImageHeight = $component->getMaxImageHeight();
-            $doResize = false;
+            $shouldResize = false;
             $imageHeight = null;
             $imageWidth = null;
             // $originalBinaryFile = $file->get();
@@ -224,17 +224,17 @@ class BaseFileUpload extends Field
                 }
 
                 if ($maxImageWidth && $image->width() > $maxImageWidth) {
-                    $doResize = true;
+                    $shouldResize = true;
                     $imageWidth = $maxImageWidth;
                 }
 
                 if ($maxImageHeight && $image->height() > $maxImageHeight) {
-                    $doResize = true;
+                    $shouldResize = true;
                     $imageHeight = $maxImageHeight;
                 }
 
                 if ($resize) {
-                    $doResize = true;
+                    $shouldResize = true;
 
                     if ($image->height() > $image->width()) {
                         $imageHeight = $image->height() - ($image->height() * ($resize / 100));
@@ -243,7 +243,7 @@ class BaseFileUpload extends Field
                     }
                 }
 
-                if ($doResize) {
+                if ($shouldResize) {
                     $image->resize($imageWidth, $imageHeight, function ($constraint) {
                         $constraint->aspectRatio();
                     });

--- a/src/Components/BaseFileUpload.php
+++ b/src/Components/BaseFileUpload.php
@@ -58,6 +58,10 @@ class BaseFileUpload extends Field
 
     protected int | Closure | null $resize = null;
 
+    protected int | Closure | null $maxImageWidth = null;
+
+    protected int | Closure | null $maxImageHeight = null;
+
     protected bool | Closure $shouldPreserveFilenames = false;
 
     protected bool | Closure $shouldMoveFiles = false;
@@ -201,11 +205,16 @@ class BaseFileUpload extends Field
             $filename = $component->getUploadedFileNameForStorage($file);
             $optimize = $component->getOptimization();
             $resize = $component->getResize();
+            $maxImageWidth = $component->getMaxImageWidth();
+            $maxImageHeight = $component->getMaxImageHeight();
+            $doResize = false;
+            $imageHeight = null;
+            $imageWidth = null;
             // $originalBinaryFile = $file->get();
 
             if (
                 str_contains($file->getMimeType(), 'image') &&
-                ($optimize || $resize)
+                ($optimize || $resize || $maxImageWidth || $maxImageHeight)
             ) {
                 $image = InterventionImage::make($file);
 
@@ -214,17 +223,28 @@ class BaseFileUpload extends Field
                         $optimize === 'jpg' ? 70 : null;
                 }
 
+                if ($maxImageWidth && $image->width() > $maxImageWidth) {
+                    $doResize = true;
+                    $imageWidth = $maxImageWidth;
+                }
+
+                if ($maxImageHeight && $image->height() > $maxImageHeight) {
+                    $doResize = true;
+                    $imageHeight = $maxImageHeight;
+                }
+
                 if ($resize) {
-                    $height = null;
-                    $width = null;
+                    $doResize = true;
 
                     if ($image->height() > $image->width()) {
-                        $height = $image->height() - ($image->height() * ($resize / 100));
+                        $imageHeight = $image->height() - ($image->height() * ($resize / 100));
                     } else {
-                        $width = $image->width() - ($image->width() * ($resize / 100));
+                        $imageWidth = $image->width() - ($image->width() * ($resize / 100));
                     }
+                }
 
-                    $image->resize($width, $height, function ($constraint) {
+                if ($doResize) {
+                    $image->resize($imageWidth, $imageHeight, function ($constraint) {
                         $constraint->aspectRatio();
                     });
                 }
@@ -495,6 +515,20 @@ class BaseFileUpload extends Field
         return $this;
     }
 
+    public function maxImageWidth(int | Closure | null $width): static
+    {
+        $this->maxImageWidth = $width;
+
+        return $this;
+    }
+
+    public function maxImageHeight(int | Closure | null $height): static
+    {
+        $this->maxImageHeight = $height;
+
+        return $this;
+    }
+
     public function storeFiles(bool | Closure $condition = true): static
     {
         $this->shouldStoreFiles = $condition;
@@ -629,6 +663,16 @@ class BaseFileUpload extends Field
     public function getResize(): ?int
     {
         return $this->evaluate($this->resize);
+    }
+
+    public function getMaxImageWidth(): ?int
+    {
+        return $this->evaluate($this->maxImageWidth);
+    }
+
+    public function getMaxImageHeight(): ?int
+    {
+        return $this->evaluate($this->maxImageHeight);
     }
 
     public function getMaxParallelUploads(): ?int

--- a/src/Components/SpatieMediaLibraryFileUpload.php
+++ b/src/Components/SpatieMediaLibraryFileUpload.php
@@ -144,7 +144,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
             $resize = $component->getResize();
             $maxImageWidth = $component->getMaxImageWidth();
             $maxImageHeight = $component->getMaxImageHeight();
-            $doResize = false;
+            $shouldResize = false;
             $imageHeight = null;
             $imageWidth = null;
 
@@ -160,17 +160,17 @@ class SpatieMediaLibraryFileUpload extends FileUpload
                 }
 
                 if ($maxImageWidth && $image->width() > $maxImageWidth) {
-                    $doResize = true;
+                    $shouldResize = true;
                     $imageWidth = $maxImageWidth;
                 }
 
                 if ($maxImageHeight && $image->height() > $maxImageHeight) {
-                    $doResize = true;
+                    $shouldResize = true;
                     $imageHeight = $maxImageHeight;
                 }
 
                 if ($resize) {
-                    $doResize = true;
+                    $shouldResize = true;
 
                     if ($image->height() > $image->width()) {
                         $imageHeight = $image->height() - ($image->height() * ($resize / 100));
@@ -179,7 +179,7 @@ class SpatieMediaLibraryFileUpload extends FileUpload
                     }
                 }
 
-                if ($doResize) {
+                if ($shouldResize) {
                     $image->resize($imageWidth, $imageHeight, function ($constraint) {
                         $constraint->aspectRatio();
                     });


### PR DESCRIPTION
Hi there! 👋

I encountered an issue where users were uploading unnecessarily large images, even though a certain size would be sufficient for my application. While I could use the optimize() function, this would resize every image, including those already within a reasonable size, which wasn’t ideal.

To address this, I’ve introduced two new functions that allow resizing only when needed, while leaving appropriately sized images untouched. This provides greater flexibility and ensures that images remain high quality when resizing isn’t necessary.

I’m open to any feedback! I also considered adding minImageWidth() and maxImageHeight(), but I felt that increasing image sizes might lead to a loss of clarity or introduce blurriness. However, if you think these would be valuable additions, I’d be happy to include them.

Looking forward to your thoughts! 🚀

Best,
Augus van Gils